### PR TITLE
Add and update tournament endpoints for player and couple management

### DIFF
--- a/app/routers/player/player.py
+++ b/app/routers/player/player.py
@@ -1,6 +1,6 @@
 from fastapi import Depends, APIRouter, status, HTTPException
 from sqlalchemy.orm import Session
-
+from fastapi.responses import JSONResponse
 from ... import models
 from ... import schemas, oauth2
 from ...db import get_db
@@ -39,8 +39,6 @@ def create_player(
     return new_player
 
 
-
-from fastapi.responses import JSONResponse
 
 @router.post("/from-playtomic/", status_code=status.HTTP_201_CREATED, response_model=schemas.PlayerOut)
 def create_player_from_playtomic(

--- a/app/routers/tournaments/tournament.py
+++ b/app/routers/tournaments/tournament.py
@@ -4,6 +4,8 @@ from ... import schemas, oauth2
 from ...db import get_db
 from ...function.tournament import create_new_tournament
 from ... import models
+from datetime import datetime
+
 router = APIRouter(
     prefix="/tournament",
     tags=['Tournaments']
@@ -30,6 +32,58 @@ def create_tournament(
     return new_tournament
 
 
+@router.get("/{id}", response_model=schemas.TournamentOut)
+def get_tournament_by_id(
+    id: int,
+    db: Session = Depends(get_db),
+    current_company: int = Depends(oauth2.get_current_user)
+):
+    # Check if the tournament exists and is owned by the current company
+    tournament = db.query(models.Tournament).filter(models.Tournament.id == id).first()
+    
+    if not tournament:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Tournament not found")
+    
+    if tournament.company_id != current_company.id:
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Unauthorized access to this tournament")
+    
+    return tournament
+
+
+@router.put("/{id}", response_model=schemas.TournamentOut)
+def update_tournament(
+    id: int,
+    tournament_update: schemas.TournamentUpdate,
+    db: Session = Depends(get_db),
+    current_company: int = Depends(oauth2.get_current_user)
+):
+    # Check if the tournament exists and is owned by the current company
+    tournament_query = db.query(models.Tournament).filter(models.Tournament.id == id)
+    tournament = tournament_query.first()
+    
+    if not tournament:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Tournament not found")
+    
+    if tournament.company_id != current_company.id:
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Unauthorized access to this tournament")
+    
+    # Process image URLs if provided
+    update_data = tournament_update.dict(exclude_unset=True)
+    if "images" in update_data and update_data["images"] is not None:
+        update_data["images"] = [str(url) for url in update_data["images"]]
+    
+    # Apply the updates
+    tournament_query.update(update_data, synchronize_session=False)
+    
+    # Update the updated_at timestamp
+    tournament.updated_at = datetime.now()
+    
+    db.commit()
+    db.refresh(tournament)
+    
+    return tournament
+
+
 @router.post("/player/", response_model=schemas.TournamentPlayerOut)
 def add_player_to_tournament(
     payload: schemas.TournamentPlayerCreate,
@@ -53,12 +107,14 @@ def add_player_to_tournament(
     if not player:
         raise HTTPException(status_code=404, detail="Player not found")
 
-    # Check if the player is already in the tournament
-    existing_entry = db.query(models.TournamentPlayer).filter(
+    # Check if the player is already active in the tournament
+    active_entry = db.query(models.TournamentPlayer).filter(
         payload.tournament_id == models.TournamentPlayer.tournament_id,
-        payload.player_id == models.TournamentPlayer.player_id
+        payload.player_id == models.TournamentPlayer.player_id,
+        models.TournamentPlayer.deleted_at.is_(None)
     ).first()
-    if existing_entry:
+    
+    if active_entry:
         raise HTTPException(status_code=400, detail="Player is already in the tournament")
 
     #. Check if the player is associated with the current company
@@ -68,16 +124,30 @@ def add_player_to_tournament(
     if not player_company:
         raise HTTPException(status_code=403, detail="Player not associated with this company")
 
-    # Create a new tournament player entry
-    new_tournament_player = models.TournamentPlayer(
-        tournament_id=payload.tournament_id,
-        player_id=payload.player_id
-    )
-    db.add(new_tournament_player)
-    db.commit()
-    db.refresh(new_tournament_player)
-
-    return new_tournament_player
+    # Check if there's a soft-deleted entry for this player in this tournament
+    deleted_entry = db.query(models.TournamentPlayer).filter(
+        payload.tournament_id == models.TournamentPlayer.tournament_id,
+        payload.player_id == models.TournamentPlayer.player_id,
+        models.TournamentPlayer.deleted_at.is_not(None)
+    ).first()
+    
+    if deleted_entry:
+        # Reactivate the player by clearing the deleted_at field
+        deleted_entry.deleted_at = None
+        deleted_entry.updated_at = datetime.now()
+        db.commit()
+        db.refresh(deleted_entry)
+        return deleted_entry
+    else:
+        # Create a new tournament player entry
+        new_tournament_player = models.TournamentPlayer(
+            tournament_id=payload.tournament_id,
+            player_id=payload.player_id
+        )
+        db.add(new_tournament_player)
+        db.commit()
+        db.refresh(new_tournament_player)
+        return new_tournament_player
 
 
 @router.get("/{id}/player", response_model=list[schemas.TournamentPlayerOut])
@@ -99,10 +169,52 @@ def get_tournament_players(
         db.query(models.TournamentPlayer)
         .options(joinedload(models.TournamentPlayer.player))
         .filter(id == models.TournamentPlayer.tournament_id)
+        .filter(models.TournamentPlayer.deleted_at.is_(None))
         .all()
     )
 
     return tournament_players
+
+@router.delete("/{tournament_id}/player/{player_id}", status_code=status.HTTP_204_NO_CONTENT)
+def delete_player_from_tournament(
+    tournament_id: int,
+    player_id: int,
+    db: Session = Depends(get_db),
+    current_company: int = Depends(oauth2.get_current_user)
+):
+    # Check if the tournament exists and is owned by the current company
+    tournament = db.query(models.Tournament).filter(tournament_id == models.Tournament.id).first()
+    if not tournament:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Tournament not found")
+    if tournament.company_id != current_company.id:
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Unauthorized access to this tournament")
+    
+    # Find the tournament player
+    tournament_player = db.query(models.TournamentPlayer).filter(
+        models.TournamentPlayer.tournament_id == tournament_id,
+        models.TournamentPlayer.player_id == player_id
+    ).first()
+    
+    if not tournament_player:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Player not found in this tournament")
+    
+    # First find any couples that include this player
+    couples_to_delete = db.query(models.TournamentCouple).filter(
+        models.TournamentCouple.tournament_id == tournament_id,
+        (models.TournamentCouple.first_player_id == player_id) | 
+        (models.TournamentCouple.second_player_id == player_id)
+    ).all()
+    
+    # Delete the couples that include this player
+    for couple in couples_to_delete:
+        db.delete(couple)
+    
+    # Soft delete the player from the tournament
+    tournament_player.deleted_at = datetime.now()
+    
+    db.commit()
+    
+    return None
 
 @router.post("/{id}/couple", response_model=schemas.TournamentCoupleOut, status_code=status.HTTP_201_CREATED)
 def create_tournament_couple(
@@ -208,6 +320,121 @@ def get_tournament_couples(
     )
 
     return couples
+
+@router.put("/{tournament_id}/couple/{couple_id}", response_model=schemas.TournamentCoupleOut)
+def update_tournament_couple(
+    tournament_id: int,
+    couple_id: int,
+    couple_update: schemas.TournamentCoupleUpdate,
+    db: Session = Depends(get_db),
+    current_company: int = Depends(oauth2.get_current_user)
+):
+    # Check if the tournament exists and is owned by the current company
+    tournament = db.query(models.Tournament).filter(tournament_id == models.Tournament.id).first()
+    if not tournament:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Tournament not found")
+    if tournament.company_id != current_company.id:
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Unauthorized access to this tournament")
+    
+    # Find the couple
+    couple = db.query(models.TournamentCouple).filter(
+        models.TournamentCouple.id == couple_id,
+        models.TournamentCouple.tournament_id == tournament_id,
+        models.TournamentCouple.deleted_at.is_(None)
+    ).first()
+    
+    if not couple:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Couple not found in this tournament")
+    
+    # Check if we're updating player IDs
+    if couple_update.first_player_id or couple_update.second_player_id:
+        first_player_id = couple_update.first_player_id or couple.first_player_id
+        second_player_id = couple_update.second_player_id or couple.second_player_id
+        
+        # Check if the couple has the same player for first and second
+        if first_player_id == second_player_id:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="A player cannot be paired with themselves"
+            )
+        
+        # Check if both players are in the tournament_player table for this tournament
+        players_in_tournament = db.query(models.TournamentPlayer).filter(
+            tournament_id == models.TournamentPlayer.tournament_id,
+            models.TournamentPlayer.player_id.in_([first_player_id, second_player_id]),
+            models.TournamentPlayer.deleted_at.is_(None)
+        ).all()
+        
+        if len(players_in_tournament) != 2:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="One or both players are not in this tournament"
+            )
+            
+        # Check if the couple already exists (regardless of player order)
+        existing_couple = db.query(models.TournamentCouple).filter(
+            tournament_id == models.TournamentCouple.tournament_id,
+            models.TournamentCouple.id != couple_id,  # Exclude the current couple
+            models.TournamentCouple.deleted_at.is_(None),
+            (
+                (first_player_id == models.TournamentCouple.first_player_id) &
+                (models.TournamentCouple.second_player_id == second_player_id)
+            ) | (
+                (models.TournamentCouple.first_player_id == second_player_id) &
+                (models.TournamentCouple.second_player_id == first_player_id)
+            )
+        ).first()
+        
+        if existing_couple:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="This couple already exists in the tournament (including reverse order)"
+            )
+    
+    # Update couple attributes that were provided
+    if couple_update.first_player_id is not None:
+        couple.first_player_id = couple_update.first_player_id
+    if couple_update.second_player_id is not None:
+        couple.second_player_id = couple_update.second_player_id
+    if couple_update.name is not None:
+        couple.name = couple_update.name
+    
+    couple.updated_at = datetime.now()
+    db.commit()
+    db.refresh(couple)
+    
+    return couple
+
+
+@router.delete("/{tournament_id}/couple/{couple_id}", status_code=status.HTTP_204_NO_CONTENT)
+def delete_tournament_couple(
+    tournament_id: int,
+    couple_id: int,
+    db: Session = Depends(get_db),
+    current_company: int = Depends(oauth2.get_current_user)
+):
+    # Check if the tournament exists and is owned by the current company
+    tournament = db.query(models.Tournament).filter(tournament_id == models.Tournament.id).first()
+    if not tournament:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Tournament not found")
+    if tournament.company_id != current_company.id:
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Unauthorized access to this tournament")
+    
+    # Find the couple
+    couple = db.query(models.TournamentCouple).filter(
+        models.TournamentCouple.id == couple_id,
+        models.TournamentCouple.tournament_id == tournament_id,
+        models.TournamentCouple.deleted_at.is_(None)
+    ).first()
+    
+    if not couple:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Couple not found in this tournament")
+    
+    # Soft delete by setting deleted_at timestamp
+    couple.deleted_at = datetime.now()
+    db.commit()
+    
+    return None
 
 @router.get("/", response_model=list[schemas.TournamentOut])
 def get_all_tournaments(

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -54,6 +54,18 @@ class TournamentOut(TournamentBase):
     class Config:
         orm_mode = True
 
+class TournamentUpdate(BaseModel):
+    name: Optional[str] = None
+    description: Optional[str] = None
+    images: Optional[List[str]] = None
+    start_date: Optional[datetime] = None
+    end_date: Optional[datetime] = None
+    players_number: Optional[int] = None
+    full_description: Optional[Any] = None
+
+    class Config:
+        orm_mode = True
+
 class PlayersBase(BaseModel):
     nickname: str
     gender: int


### PR DESCRIPTION
 This PR adds and updates tournament-related endpoints:

   - Added endpoint to get tournament by ID with ownership verification
   - Added endpoint to update tournament with optional fields
   - Added endpoint to delete player from tournament (with proper handling of related couples)
   - Added endpoint to update couple information
   - Added endpoint to delete couple from tournament
   - Fixed tournament player management to allow re-adding previously removed players
   - Updated player and couple GET endpoints to exclude soft-deleted records